### PR TITLE
Optimizations to TextAnalysis

### DIFF
--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -193,18 +193,21 @@ end
 inverse_index(crps::Corpus) = crps.inverse_index
 
 function update_inverse_index!(crps::Corpus)
-    crps.inverse_index = Dict{UTF8String, Array{Int, 1}}()
+    idx = Dict{UTF8String, Array{Int, 1}}()
     for i in 1:length(crps)
         doc = crps[i]
-        ngs = ngrams(doc)
-        for ngram in keys(ngs)
-            if haskey(crps.inverse_index, ngram)
-                push!(crps.inverse_index[ngram], i)
+        for ngram in (isa(doc, NGramDocument) ? keys(ngrams(doc)) : tokens(doc))
+            if haskey(idx, ngram)
+                push!(idx[ngram], i)
             else
-                crps.inverse_index[ngram] = [i]
+                idx[ngram] = [i]
             end
         end
     end
+    for key in keys(idx)
+        idx[key] = unique(idx[key])
+    end
+    crps.inverse_index = idx
 end
 
 index_size(crps::Corpus) = length(keys(crps.inverse_index))

--- a/src/document.jl
+++ b/src/document.jl
@@ -58,7 +58,7 @@ StringDocument(txt::String) = StringDocument(utf8(txt), DocumentMetadata())
 ##############################################################################
 
 type TokenDocument <: AbstractDocument
-    tokens::Vector{UTF8String}
+    tokens::Vector{String}
     metadata::DocumentMetadata
 end
 function TokenDocument(txt::String, dm::DocumentMetadata)
@@ -70,7 +70,7 @@ function TokenDocument(txt::String)
 end
 function TokenDocument{T <: String}(tkns::Vector{T})
     dm = DocumentMetadata()
-    TokenDocument(convert(Vector{UTF8String}, tkns), dm)
+    TokenDocument(tkns, dm)
 end
 
 ##############################################################################
@@ -249,7 +249,7 @@ function Document(str::String)
 end
 
 function Document{T <: String}(tkns::Vector{T})
-    TokenDocument(convert(Vector{UTF8String}, tkns))
+    TokenDocument(tkns)
 end
 
 function Document(ng::Dict{UTF8String, Int})

--- a/src/document.jl
+++ b/src/document.jl
@@ -80,7 +80,7 @@ end
 ##############################################################################
 
 type NGramDocument <: AbstractDocument
-    ngrams::Dict{UTF8String, Int}
+    ngrams::Dict
     n::Int
     metadata::DocumentMetadata
 end

--- a/src/ngramizer.jl
+++ b/src/ngramizer.jl
@@ -4,9 +4,9 @@
 #
 ##############################################################################
 
-function ngramize{S <: Language, T <: String}(::Type{S},
-                                              words::Vector{T},
-                                              n::Int)
+function ngramize{S <: Language, T <: String}(::Type{S}, words::Vector{T}, n::Int)
+    (n == 1) && return onegramize(S, words)
+
     n_words = length(words)
 
     tokens = Dict{UTF8String, Int}()
@@ -20,3 +20,15 @@ function ngramize{S <: Language, T <: String}(::Type{S},
 
     return tokens
 end
+
+function onegramize{S <: Language, T <: String}(::Type{S}, words::Vector{T})
+    n_words = length(words)
+    tokens = Dict{T, Int}()
+
+    for word in words
+        tokens[word] = get(tokens, word, 0) + 1
+    end
+
+    tokens
+end
+

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -5,5 +5,6 @@
 ##############################################################################
 
 function tokenize{S <: Language}(::Type{S}, s::String)
-    return convert(Array{UTF8String, 1}, matchall(r"[^\s]+", s))
+    #return convert(Array{UTF8String, 1}, matchall(r"[^\s]+", s))
+    return matchall(r"[^\s]+", s)
 end

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -5,6 +5,5 @@
 ##############################################################################
 
 function tokenize{S <: Language}(::Type{S}, s::String)
-    #return convert(Array{UTF8String, 1}, matchall(r"[^\s]+", s))
     return matchall(r"[^\s]+", s)
 end


### PR DESCRIPTION
These are few proposed optimizations to speed up text analysis, based on observations while indexing common crawl repository.

- TokenDocument modified to use SubStrings instead of UTF8String
- Specialized stemmer for handling substrings
- Creating inverse index of a document other than NGramDocument just gets tokens instead of getting one-grams
- Specialized ngram creation for one gram

With the above changes I notice close to 50% speed up with the specific cases that I am trying out.
