### PR TITLE
Multiple changes for speed improvement

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3
 Languages
 DataFrames
 BinDeps
+Compat

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,7 +39,8 @@ if !isfile(binpath)
     end
 
     @windows_only begin
-        Base.warn("No integrated stemmer available on Windows yet. Place a compiled Snowball stemmer dll at $binpath for stemming to work.")
+        Base.warn("No integrated stemmer available on Windows yet.\n" *
+                  "Place a compiled Snowball stemmer dll at $binpath for stemming to work.")
     end
 end
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using BinDeps
 
 @BinDeps.setup
 
-libstemmer = library_dependency("libstemmer", aliases=["libstemmer"])
+libstemmer = library_dependency("libstemmer", aliases=["libstemmer.so", "libstemmer.dll"])
 
 prefix=joinpath(BinDeps.depsdir(libstemmer),"usr")
 dnlddir = joinpath(BinDeps.depsdir(libstemmer), "downloads")
@@ -19,24 +19,29 @@ for path in [prefix, dnlddir, srchome, bindir]
     !isdir(path) && mkdir(path)
 end
 
-@unix_only begin
-    run(download_cmd("http://snowball.tartarus.org/dist/snowball_code.tgz",dnldfile))
-    cd(srchome)
-    run(`tar xvzf $dnldfile`)
-    cd(srcdir)
-    run(`cat $patchpath` |> `patch`)
-    for mkcmd in (:gnumake, :gmake, :make)
-        try
-            if success(`$mkcmd`)
-                cp(joinpath(srcdir, "libstemmer.so.0d.0.0"), binpath)
-                break
+if !isfile(binpath)
+    @unix_only begin
+        run(download_cmd("http://snowball.tartarus.org/dist/snowball_code.tgz",dnldfile))
+        cd(srchome)
+        run(`tar xvzf $dnldfile`)
+        cd(srcdir)
+        run(`cat $patchpath` |> `patch`)
+        for mkcmd in (:gnumake, :gmake, :make)
+            try
+                if success(`$mkcmd`)
+                    cp(joinpath(srcdir, "libstemmer.so.0d.0.0"), binpath)
+                    break
+                end
+            catch
+                continue
             end
-        catch
-            continue
         end
+    end
+
+    @windows_only begin
+        Base.warn("No integrated stemmer available on Windows yet. Place a compiled Snowball stemmer dll at $binpath for stemming to work.")
     end
 end
 
-@windows_only begin
-    Base.warn("No integrated stemmer available on Windows yet. Place a compiled Snowball stemmer dll at $binpath for stemming to work.")
-end
+provides(Binaries, bindir, libstemmer)
+

--- a/src/TextAnalysis.jl
+++ b/src/TextAnalysis.jl
@@ -4,7 +4,7 @@ module TextAnalysis
     using Languages
     using DataFrames
     using BinDeps
-    using MutableStrings
+    using Compat
 
     importall Base
     import DataFrames.DataFrame

--- a/src/TextAnalysis.jl
+++ b/src/TextAnalysis.jl
@@ -4,6 +4,7 @@ module TextAnalysis
     using Languages
     using DataFrames
     using BinDeps
+    using MutableStrings
 
     importall Base
     import DataFrames.DataFrame

--- a/src/corpus.jl
+++ b/src/corpus.jl
@@ -13,8 +13,18 @@ type Corpus
     inverse_index::Dict{UTF8String, Vector{Int}}
     h::TextHashFunction
 end
-Corpus(docs::Vector{GenericDocument})   = Corpus(docs, 0, Dict{UTF8String, Int}(), Dict{UTF8String, Vector{Int}}(), TextHashFunction())
-Corpus(docs::Vector{Any})               = Corpus(convert(Array{GenericDocument,1}, docs)) 
+
+function Corpus(docs::Vector{GenericDocument})
+    Corpus(
+        docs, 
+        0,
+        Dict{UTF8String, Int}(),
+        Dict{UTF8String, Vector{Int}}(),
+        TextHashFunction()
+    )
+end
+
+Corpus(docs::Vector{Any}) = Corpus(convert(Array{GenericDocument,1}, docs))
 
 ##############################################################################
 #
@@ -167,7 +177,8 @@ function update_lexicon!(crps::Corpus)
 end
 
 lexicon_size(crps::Corpus) = length(keys(crps.lexicon))
-lexical_frequency(crps::Corpus, term::String) = (get(crps.lexicon, term, 0) / crps.total_terms)
+lexical_frequency(crps::Corpus, term::String) = 
+    (get(crps.lexicon, term, 0) / crps.total_terms)
 
 ##############################################################################
 #
@@ -183,7 +194,8 @@ function update_inverse_index!(crps::Corpus)
     idx = Dict{UTF8String, Array{Int, 1}}()
     for i in 1:length(crps)
         doc = crps.documents[i]
-        ngram_arr = convert(Array{UTF8String,1}, isa(doc, NGramDocument) ? collect(keys(ngrams(doc))) : tokens(doc))
+        ngram_arr = isa(doc, NGramDocument) ? collect(keys(ngrams(doc))) : tokens(doc)
+        ngram_arr = convert(Array{UTF8String,1}, ngram_arr)
         for ngram in ngram_arr
             if haskey(idx, ngram)
                 push!(idx[ngram], i)

--- a/src/document.jl
+++ b/src/document.jl
@@ -10,13 +10,7 @@ type DocumentMetadata
     author::UTF8String
     timestamp::UTF8String
 end
-
-DocumentMetadata() = DocumentMetadata(
-    EnglishLanguage,
-    utf8("Unnamed Document"),
-    utf8("Unknown Author"),
-    utf8("Unknown Time")
-)
+DocumentMetadata() = DocumentMetadata(EnglishLanguage, utf8("Unnamed Document"), utf8("Unknown Author"), utf8("Unknown Time"))
 
 ##############################################################################
 #
@@ -50,11 +44,12 @@ end
 ##############################################################################
 
 type StringDocument <: AbstractDocument
-    text::UTF8String
+    text::String
     metadata::DocumentMetadata
 end
 
 StringDocument(txt::String) = StringDocument(utf8(txt), DocumentMetadata())
+StringDocument(txt::MutableString) = StringDocument(txt, DocumentMetadata())
 
 ##############################################################################
 #
@@ -66,20 +61,9 @@ type TokenDocument <: AbstractDocument
     tokens::Vector{String}
     metadata::DocumentMetadata
 end
-
-function TokenDocument(txt::String, dm::DocumentMetadata)
-    TokenDocument(tokenize(dm.language, utf8(txt)), dm)
-end
-
-function TokenDocument(txt::String)
-    dm = DocumentMetadata()
-    TokenDocument(tokenize(EnglishLanguage, utf8(txt)), dm)
-end
-
-function TokenDocument{T <: String}(tkns::Vector{T})
-    dm = DocumentMetadata()
-    TokenDocument(tkns, dm)
-end
+TokenDocument(txt::String, dm::DocumentMetadata) = TokenDocument(tokenize(dm.language, utf8(txt)), dm)
+TokenDocument(txt::String) = TokenDocument(txt, DocumentMetadata())
+TokenDocument{T <: String}(tkns::Vector{T}) = TokenDocument(tkns, DocumentMetadata())
 
 ##############################################################################
 #
@@ -88,41 +72,13 @@ end
 ##############################################################################
 
 type NGramDocument <: AbstractDocument
-    ngrams::Dict
+    ngrams::Dict{String,Int}
     n::Int
     metadata::DocumentMetadata
 end
-
-function NGramDocument(txt::String, dm::DocumentMetadata)
-    NGramDocument(ngramize(dm.language, utf8(txt), 1),
-                  1, dm)
-end
-
-function NGramDocument(txt::String, n::Integer)
-    dm = DocumentMetadata()
-    NGramDocument(ngramize(EnglishLanguage,
-                           tokenize(dm.language, utf8(txt)), n),
-                  n, dm)
-end
-
-function NGramDocument(txt::String)
-    dm = DocumentMetadata()
-    NGramDocument(ngramize(EnglishLanguage,
-                           tokenize(dm.language, utf8(txt)), 1),
-                  1, dm)
-end
-
-function NGramDocument{T <: String}(ng::Dict{T, Int}, n::Int)
-    dm = DocumentMetadata()
-    NGramDocument(convert(Dict{UTF8String, Int}, ng),
-                  n, dm)
-end
-
-function NGramDocument{T <: String}(ng::Dict{T, Int})
-    dm = DocumentMetadata()
-    NGramDocument(convert(Dict{UTF8String, Int}, ng),
-                  1, dm)
-end
+NGramDocument(txt::String, dm::DocumentMetadata, n::Integer=1) = NGramDocument(ngramize(dm.language, tokenize(dm.language, utf8(txt)), n), n, dm)
+NGramDocument(txt::String, n::Integer=1) = NGramDocument(txt, DocumentMetadata(), n)
+NGramDocument{T <: String}(ng::Dict{T, Int}, n::Integer=1) = NGramDocument(merge(Dict{String,Int}(), ng), n, DocumentMetadata())
 
 ##############################################################################
 #
@@ -131,34 +87,16 @@ end
 ##############################################################################
 
 function text(fd::FileDocument)
-    if isfile(fd.filename)
-        return readall(fd.filename)
-    else
-        error("Can't find file: $(fd.filename)")
-    end
+    !isfile(fd.filename) && error("Can't find file: $(fd.filename)")
+    readall(fd.filename)
 end
 
-function text(sd::StringDocument)
-    return sd.text
-end
+text(sd::StringDocument) = sd.text
+text(td::TokenDocument) = (warn("TokenDocument's can only approximate the original text"); join(td.tokens, " "))
+text(ngd::NGramDocument) = error("The text of an NGramDocument cannot be reconstructed")
 
-function text(td::TokenDocument)
-    warn("TokenDocument's can only approximate the original text")
-    return join(td.tokens, " ")
-end
-
-function text(ngd::NGramDocument)
-    error("The text of an NGramDocument cannot be reconstructed")
-end
-
-function text!(sd::StringDocument, new_text::String)
-    sd.text = new_text
-    return sd.text
-end
-
-function text!(d::AbstractDocument, new_text::String)
-    error("The text of a $(typeof(d)) cannot be edited")
-end
+text!(sd::StringDocument, new_text::String) = (sd.text = new_text)
+text!(d::AbstractDocument, new_text::String) = error("The text of a $(typeof(d)) cannot be edited")
 
 ##############################################################################
 #
@@ -166,25 +104,12 @@ end
 #
 ##############################################################################
 
-function tokens(d::Union(FileDocument, StringDocument))
-    tokenize(language(d), text(d))
-end
+tokens(d::Union(FileDocument, StringDocument)) = tokenize(language(d), text(d))
+tokens(d::TokenDocument) = d.tokens
+tokens(d::NGramDocument) = error("The tokens of an NGramDocument cannot be reconstructed")
 
-function tokens(d::TokenDocument)
-    d.tokens
-end
-
-function tokens(d::NGramDocument)
-    error("The tokens of an NGramDocument cannot be reconstructed")
-end
-
-function tokens!{T <: String}(d::TokenDocument, new_tokens::Vector{T})
-    d.tokens = new_tokens
-end
-
-function tokens!{T <: String}(d::AbstractDocument, new_tokens::Vector{T})
-    error("The tokens of a $(typeof(d)) cannot be directly edited")
-end
+tokens!{T <: String}(d::TokenDocument, new_tokens::Vector{T}) = (d.tokens = new_tokens)
+tokens!{T <: String}(d::AbstractDocument, new_tokens::Vector{T}) = error("The tokens of a $(typeof(d)) cannot be directly edited")
 
 ##############################################################################
 #
@@ -192,29 +117,13 @@ end
 #
 ##############################################################################
 
-function ngrams(d::NGramDocument, n::Integer)
-    error("The n-gram complexity of an NGramDocument cannot be increased")
-end
+ngrams(d::NGramDocument, n::Integer) = error("The n-gram complexity of an NGramDocument cannot be increased")
+ngrams(d::AbstractDocument, n::Integer) = ngramize(language(d), tokens(d), n)
+ngrams(d::NGramDocument) = d.ngrams
+ngrams(d::AbstractDocument) = ngrams(d, 1)
 
-function ngrams(d::AbstractDocument, n::Integer)
-    ngramize(language(d), tokens(d), n)
-end
-
-function ngrams(d::NGramDocument)
-    d.ngrams
-end
-
-function ngrams(d::AbstractDocument)
-    ngrams(d, 1)
-end
-
-function ngrams!(d::NGramDocument, new_ngrams::Dict{UTF8String, Int})
-    d.ngrams = new_ngrams
-end
-
-function ngrams!(d::AbstractDocument, new_ngrams::Dict{UTF8String, Int})
-    error("The n-grams of $(typeof(d)) cannot be directly edited")
-end
+ngrams!(d::NGramDocument, new_ngrams::Dict{String, Int}) = (d.ngrams = new_ngrams)
+ngrams!(d::AbstractDocument, new_ngrams::Dict) = error("The n-grams of $(typeof(d)) cannot be directly edited")
 
 ##############################################################################
 #
@@ -246,12 +155,7 @@ end
 #
 ##############################################################################
 
-typealias GenericDocument Union(
-    FileDocument,
-    StringDocument,
-    TokenDocument,
-    NGramDocument
-)
+typealias GenericDocument Union(FileDocument, StringDocument, TokenDocument, NGramDocument)
 
 ##############################################################################
 #
@@ -259,21 +163,9 @@ typealias GenericDocument Union(
 #
 ##############################################################################
 
-function Document(str::String)
-    if isfile(str)
-        FileDocument(str)
-    else
-        StringDocument(str)
-    end
-end
-
-function Document{T <: String}(tkns::Vector{T})
-    TokenDocument(tkns)
-end
-
-function Document(ng::Dict{UTF8String, Int})
-    NGramDocument(ng)
-end
+Document(str::String) = isfile(str) ? FileDocument(str) : StringDocument(str)
+Document{T <: String}(tkns::Vector{T}) = TokenDocument(tkns)
+Document(ng::Dict{UTF8String, Int}) = NGramDocument(ng)
 
 ##############################################################################
 #
@@ -281,30 +173,11 @@ end
 #
 ##############################################################################
 
-function Base.convert(::Type{StringDocument},
-                 d::FileDocument)
-    new_d = StringDocument(text(d))
-    new_d.metadata = d.metadata
-    return new_d
-end
-
-function Base.convert(::Type{TokenDocument},
-                 d::Union(FileDocument, StringDocument))
-    new_d = TokenDocument(tokens(d))
-    new_d.metadata = d.metadata
-    return new_d
-end
-
-Base.convert(::Type{TokenDocument}, d::TokenDocument) = d
-
-function Base.convert(::Type{NGramDocument},
-                 d::Union(FileDocument, StringDocument, TokenDocument))
-    new_d = NGramDocument(ngrams(d))
-    new_d.metadata = d.metadata
-    return new_d
-end
-
-Base.convert(::Type{NGramDocument}, d::NGramDocument) = d
+convert(::Type{StringDocument}, d::FileDocument) = StringDocument(text(d), d.metadata)
+convert(::Type{TokenDocument}, d::Union(FileDocument, StringDocument)) = TokenDocument(tokens(d), d.metadata)
+convert(::Type{TokenDocument}, d::TokenDocument) = d
+convert(::Type{NGramDocument}, d::Union(FileDocument, StringDocument, TokenDocument)) = NGramDocument(ngrams(d), 1, d.metadata)
+convert(::Type{NGramDocument}, d::NGramDocument) = d
 
 ##############################################################################
 #

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -30,5 +30,5 @@ TextHashFunction() = TextHashFunction(hash, 100)
 cardinality(h::TextHashFunction) = h.cardinality
 
 function index_hash(s::String, h::TextHashFunction)
-    return int(rem(h.hash_function(s), h.cardinality)) + 1
+    return @compat(Int(rem(h.hash_function(s), h.cardinality))) + 1
 end

--- a/src/ngramizer.jl
+++ b/src/ngramizer.jl
@@ -9,7 +9,7 @@ function ngramize{S <: Language, T <: String}(::Type{S}, words::Vector{T}, n::In
 
     n_words = length(words)
 
-    tokens = Dict{UTF8String, Int}()
+    tokens = Dict{String, Int}()
 
     for m in 1:n
         for index in 1:(n_words - m + 1)

--- a/src/preprocessing.jl
+++ b/src/preprocessing.jl
@@ -1,34 +1,37 @@
 
-const strip_patterns                = uint32(0)
-const strip_corrupt_utf8            = uint32(0x1) << 0
-const strip_case                    = uint32(0x1) << 1
-const stem_words                    = uint32(0x1) << 2
-const tag_part_of_speech            = uint32(0x1) << 3
+const strip_patterns                = @compat(UInt32(0))
+const strip_corrupt_utf8            = @compat(UInt32(0x1)) << 0
+const strip_case                    = @compat(UInt32(0x1)) << 1
+const stem_words                    = @compat(UInt32(0x1)) << 2
+const tag_part_of_speech            = @compat(UInt32(0x1)) << 3
 
-const strip_whitespace              = uint32(0x1) << 5
-const strip_punctuation             = uint32(0x1) << 6
-const strip_numbers                 = uint32(0x1) << 7
-const strip_non_letters             = uint32(0x1) << 8
+const strip_whitespace              = @compat(UInt32(0x1)) << 5
+const strip_punctuation             = @compat(UInt32(0x1)) << 6
+const strip_numbers                 = @compat(UInt32(0x1)) << 7
+const strip_non_letters             = @compat(UInt32(0x1)) << 8
 
-const strip_indefinite_articles     = uint32(0x1) << 9
-const strip_definite_articles       = uint32(0x1) << 10
-const strip_articles                = (strip_indefinite_articles | strip_definite_articles)
+const strip_indefinite_articles     = @compat(UInt32(0x1)) << 9
+const strip_definite_articles       = @compat(UInt32(0x1)) << 10
+const strip_articles                = (strip_indefinite_articles | 
+                                       strip_definite_articles)
 
-const strip_prepositions            = uint32(0x1) << 13
-const strip_pronouns                = uint32(0x1) << 14
+const strip_prepositions            = @compat(UInt32(0x1)) << 13
+const strip_pronouns                = @compat(UInt32(0x1)) << 14
 
-const strip_stopwords               = uint32(0x1) << 16
-const strip_sparse_terms            = uint32(0x1) << 17
-const strip_frequent_terms          = uint32(0x1) << 18
+const strip_stopwords               = @compat(UInt32(0x1)) << 16
+const strip_sparse_terms            = @compat(UInt32(0x1)) << 17
+const strip_frequent_terms          = @compat(UInt32(0x1)) << 18
 
-const strip_html_tags               = uint32(0x1) << 20
+const strip_html_tags               = @compat(UInt32(0x1)) << 20
 
 const alpha_sparse      = 0.05
 const alpha_frequent    = 0.95
 
 const regex_cache = Dict{String, Regex}()
 function mk_regex(regex_string)
-    d = haskey(regex_cache, regex_string) ? regex_cache[regex_string] : (regex_cache[regex_string] = Regex(regex_string, 0))
+    d = haskey(regex_cache, regex_string) ? 
+            regex_cache[regex_string] : 
+            (regex_cache[regex_string] = Regex(regex_string, 0))
     (length(regex_cache) > 50) && empty!(regex_cache)
     d
 end
@@ -87,15 +90,12 @@ end
 #
 ##############################################################################
 
-#remove_case(s::MutableASCIIString) = lowercase!(s)
-#remove_case(s::MutableUTF8String) = lowercase!(s)
-remove_case(s::MutableString) = lowercase!(s)
 remove_case{T <: String}(s::T) = lowercase(s)
 
 remove_case!(d::FileDocument) = error("FileDocument cannot be modified")
 
 function remove_case!(d::StringDocument)
-    isa(d.text, MutableString) ? remove_case(d.text) : (d.text = remove_case(d.text))
+    d.text = remove_case(d.text)
     nothing
 end
 
@@ -137,7 +137,9 @@ function remove_html_tags(s::String)
     remove_patterns(s, html_tags)
 end
 
-remove_html_tags!(d::AbstractDocument) = error("HTML tags can be removed only from a StringDocument")
+function remove_html_tags!(d::AbstractDocument)
+    error("HTML tags can be removed only from a StringDocument")
+end
 
 function remove_html_tags!(d::StringDocument)
     d.text = remove_html_tags(d.text)
@@ -155,7 +157,8 @@ end
 # Remove specified words
 #
 ##############################################################################
-function remove_words!{T <: String}(entity::Union(AbstractDocument,Corpus), words::Vector{T})
+function remove_words!{T <: String}(entity::Union(AbstractDocument,Corpus),
+                                    words::Vector{T})
     skipwords = Set{String}()
     union!(skipwords, words)
     prepare!(entity, strip_patterns, skip_words = skipwords)
@@ -293,12 +296,6 @@ end
 
 ##
 # internal helper methods
-#mk_blank(x::MutableASCIIString, y::Range1) = (x.data[y] = uint8(' '); nothing)
-
-function remove_patterns(s::MutableString, rex::Regex)
-    replace!(s, rex, ' ')
-    s
-end
 
 function remove_patterns(s::String, rex::Regex)
     iob = IOBuffer()

--- a/src/show.jl
+++ b/src/show.jl
@@ -21,7 +21,7 @@ function summary(d::AbstractDocument)
     o *= " * Name: $(name(d))\n"
     o *= " * Author: $(author(d))\n"
     o *= " * Timestamp: $(timestamp(d))\n"
-    if contains({TokenDocument, NGramDocument}, typeof(d))
+    if contains(Any[TokenDocument, NGramDocument], typeof(d))
         o *= " * Snippet: ***SAMPLE TEXT NOT AVAILABLE***"
     else
         sample_text = replace(text(d)[1:50], r"\s+", " ")

--- a/src/tokenizer.jl
+++ b/src/tokenizer.jl
@@ -4,6 +4,4 @@
 #
 ##############################################################################
 
-function tokenize{S <: Language}(::Type{S}, s::String)
-    return matchall(r"[^\s]+", s)
-end
+tokenize{S <: Language, T <: String}(::Type{S}, s::T) = matchall(r"[^\s]+", s)

--- a/test/corpus.jl
+++ b/test/corpus.jl
@@ -12,7 +12,7 @@ module TestCorpus
     td = TokenDocument(sample_text1)
     ngd = NGramDocument(sample_text1)
 
-    crps = Corpus({sd, fd, td, ngd})
+    crps = Corpus(Any[sd, fd, td, ngd])
 
     documents(crps)
 

--- a/test/dtm.jl
+++ b/test/dtm.jl
@@ -8,7 +8,7 @@ module TestDTM
     fd = FileDocument(sample_file)
     sd = StringDocument(text(fd))
 
-    crps = Corpus({fd, sd})
+    crps = Corpus(Any[fd, sd])
 
     m = DocumentTermMatrix(crps)
     dtm(m)

--- a/test/ngramizer.jl
+++ b/test/ngramizer.jl
@@ -2,17 +2,18 @@ module TestNGramizer
     using Base.Test
     using Languages
     using TextAnalysis
+    using Compat
 
     sample_text = "this is some sample text"
     tkns = TextAnalysis.tokenize(Languages.EnglishLanguage, sample_text)
     ngs = TextAnalysis.ngramize(TextAnalysis.EnglishLanguage, tkns, 1)
-    @assert isequal(ngs, (UTF8String => Int)["some" => 1,
+    @assert isequal(ngs, @compat(Dict{UTF8String,Int}("some" => 1,
     	                                     "this" => 1,
     	                                     "is" => 1,
     	                                     "sample" => 1,
-    	                                     "text" => 1])
+    	                                     "text" => 1)))
     ngs = TextAnalysis.ngramize(TextAnalysis.EnglishLanguage, tkns, 2)
-    @assert isequal(ngs, (UTF8String => Int)["some" => 1,
+    @assert isequal(ngs, @compat(Dict{UTF8String,Int}("some" => 1,
                                              "this is" => 1,
                                              "some sample" => 1,
                                              "is some" => 1,
@@ -20,5 +21,5 @@ module TestNGramizer
                                              "this" => 1,
                                              "is" => 1,
                                              "sample" => 1,
-                                             "text" => 1])
+                                             "text" => 1)))
 end


### PR DESCRIPTION
This includes the following changes:
- `TokenDocument` now uses `SubString`s instead of `ByteString`
- creating inverse index gets `tokens` instead of `ngrams`
- specialize ngram creation for 1grams
- ~~`StringDocument` can work with `MutableString`. Makes it much faster during the preprocess phase.~~
- Optimized stemmer for handling substrings and words within a larger string.
- added a simple regex cache to avoid recompilations while processing large corpuses
- fixed snowball stemmer building through bindeps

Tests to create an inverse index of large number of documents from the common crawl database show significant speed improvements. Creating an inverse index of a common crawl archive (100MB compressed with around 8000 documents) now takes 80 seconds instead of 200 seconds. Relevant test code can be found at https://github.com/tanmaykm/CommonCrawl.jl and https://github.com/tanmaykm/julia_examples/tree/master/common_crawl_indexer.

This also includes the changes in PR #11, so that can be deleted if this is acceptable.
