### PR TITLE
Use predefined lexicon to generate dtm

### DIFF
--- a/src/dtm.jl
+++ b/src/dtm.jl
@@ -16,8 +16,7 @@ end
 #
 ##############################################################################
 
-function DocumentTermMatrix(crps::Corpus)
-    lex = lexicon(crps)
+function DocumentTermMatrix(crps::Corpus, lex)
     terms = sort(collect(keys(lex)))
     column_indices = Dict{UTF8String, Int}()
     for i in 1:length(terms)
@@ -47,6 +46,7 @@ function DocumentTermMatrix(crps::Corpus)
     end
     DocumentTermMatrix(dtm, terms, column_indices)
 end
+DocumentTermMatrix(crps::Corpus) = DocumentTermMatrix(crps, lexicon(crps))
 
 ##############################################################################
 #


### PR DESCRIPTION
Sometimes it is useful to generate a DocumentTermMatrix from a saved lexicon, rather than from the current corpus. 