### PR TITLE
fixes corner case for 0 words in doc for tf_idf computation

### DIFF
--- a/src/tf_idf.jl
+++ b/src/tf_idf.jl
@@ -29,7 +29,7 @@ function tf_idf!{T1 <: Real, T2 <: AbstractFloat}(dtm::AbstractMatrix{T1}, tfidf
         for j in 1:p
             words_in_document += dtm[i, j]
         end
-        tfidf[i, :] = dtm[i, :] ./ words_in_document
+        tfidf[i, :] = dtm[i, :] ./ maximum([words_in_document, 1])
     end
 
     # IDF tells us how rare a term is in the corpus

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ module TestTextAnalysis
         "corpus.jl",
         "preprocessing.jl",
         "dtm.jl",
-        "stemmer.jl"
+        "stemmer.jl",
+        "tf_idf.jl"
     ]
 
     println("Running tests:")

--- a/test/tf_idf.jl
+++ b/test/tf_idf.jl
@@ -1,24 +1,26 @@
-module TestDTM
+module TestTFIDF
     using Base.Test
     using Languages
     using TextAnalysis
 
     doc1 = "a a a sample text text"
     doc2 = "another example example text text"
-    doc3 = "another another text text text text"
+    doc3 = ""
+    doc4 = "another another text text text text"
 
     # TODO: this should work!
-    # crps = Corpus(map(StringDocument, [doc1 doc2 doc3]))
-    
-    crps = Corpus(Any[StringDocument(doc1), StringDocument(doc2), StringDocument(doc3)])
+    # crps = Corpus(map(StringDocument, [doc1 doc2 doc3 doc4]))
+
+    crps = Corpus(Any[StringDocument(doc1), StringDocument(doc2), StringDocument(doc3), StringDocument(doc4)])    
 
     update_lexicon!(crps)
     m = DocumentTermMatrix(crps)
 
     # Terms are in alphabetical ordering
-    correctweights = [0.5493061443340548 0.0 0.0 0.18310204811135158 0.0
-                      0.0 0.08109302162163289 0.43944491546724385 0.0 0.0
-                      0.0 0.13515503603605478 0.0 0.0 0.0]
+    correctweights = [0.6931471805599453 0.0 0.0 0.23104906018664842 0.09589402415059362
+	              0.0 0.13862943611198905 0.5545177444479562 0.0 0.11507282898071235
+	              0.0 0.0 0.0 0.0 0.0
+	              0.0 0.23104906018664842  0.0 0.0 0.19178804830118723]
 
     myweights = tf_idf(m)
     @test_approx_eq myweights correctweights
@@ -28,6 +30,7 @@ module TestDTM
     @test typeof(myweights) <: SparseMatrixCSC
 
     myweights = tf_idf(dtm(m, :dense))
+    @test isnan(sum(myweights)) == 0
     @test_approx_eq myweights correctweights
     @test typeof(myweights) <: Matrix
 


### PR DESCRIPTION
fixes corner case for ```tf_idf()``` calculation when document contains 0 words.

This (=zero words in doc) happens to me quite frequently when processing scanned pdf files and something goes wrong with the scan quality.
